### PR TITLE
Fix: list index out of range on printer without LED's

### DIFF
--- a/printer.py
+++ b/printer.py
@@ -549,7 +549,7 @@ class PrinterData:
 		self.bed = data['heater_bed'] #temperature, target
 		self.extruder = data['extruder'] #temperature, target
 		self.fan = data['fan']
-		if 'led %s' % self.LED[0] in data:
+		if self.LED and 'led %s' % self.LED[0] in data:
 			self.led_percentage = int(data['led %s' % self.LED[0]]['color_data'][0][3] * 256)
 		self.toolhead = data['toolhead']
 		Update = False


### PR DESCRIPTION
You get the following error on Printer without LED's:

```python
Traceback (most recent call last):
  File "/home/marluene/Documents/Bastelprojekte/3DPrinter/Dirk_Upgrade/anycubic_i3_mega_display/KlipperLCD/main.py", line 245, in <module>
    x = KlipperLCD()
  File "/home/marluene/Documents/Bastelprojekte/3DPrinter/Dirk_Upgrade/anycubic_i3_mega_display/KlipperLCD/main.py", line 27, in __init__
    self.printer.init_Webservices()
  File "/home/marluene/Documents/Bastelprojekte/3DPrinter/Dirk_Upgrade/anycubic_i3_mega_display/KlipperLCD/printer.py", line 462, in init_Webservices
    self.update_variable()
  File "/home/marluene/Documents/Bastelprojekte/3DPrinter/Dirk_Upgrade/anycubic_i3_mega_display/KlipperLCD/printer.py", line 552, in update_variable
    if 'led %s' % self.LED[0] in data:
IndexError: list index out of range
```

This PR should fix this.